### PR TITLE
Update for gnome 44

### DIFF
--- a/custom-accent-colors@demiskp/metadata.json
+++ b/custom-accent-colors@demiskp/metadata.json
@@ -4,7 +4,7 @@
     "uuid": "custom-accent-colors@demiskp",
     "version": 5,
     "shell-version": [
-        "43"
+        "44", "43"
     ],
     "url": "https://github.com/demiskp/custom-accent-colors"
 }


### PR DESCRIPTION
The extension works on Gnome44 but the version in metadata doesn't allow it to work